### PR TITLE
fix: bug - 替换图片url 后预览区域后, 图片没有更新

### DIFF
--- a/examples/react/Demo.tsx
+++ b/examples/react/Demo.tsx
@@ -1,17 +1,24 @@
-import React , { useEffect, useRef }from 'react'; 
+import React , { useEffect, useRef, useState }from 'react'; 
 import Preview from '../../src';
 import "./index.css";
 
 const Demo=()=>{
- 
+    const [url, setUrl] = useState('https://img.alicdn.com/imgextra/i4/3282796868/O1CN01gTtB5c20basEyuYsW_!!3282796868.jpg_430x430q90.jpg')
+
+    const replaceUrl = () => {
+        setUrl('https://sf6-ttcdn-tos.pstatp.com/img/user-avatar/b1e19b3de788bb023612756b337aa48c~300x300.image')
+    }
     return (
         <div style={{padding:100}}>
             <Preview>
                 <img 
-                    src={'https://img.alicdn.com/imgextra/i4/3282796868/O1CN01gTtB5c20basEyuYsW_!!3282796868.jpg_430x430q90.jpg'}
+                    src={url}
                     style={{width:500,height:500}}    
                 />
             </Preview>
+
+            <br />
+            <button onClick={replaceUrl}>替换图片url</button>
         </div>
     )
 }

--- a/src/PreviewBox.tsx
+++ b/src/PreviewBox.tsx
@@ -11,7 +11,7 @@ const PreviewBox=React.forwardRef((props:IPreviewBoxProps,ref)=>{
         target, 
         size,
         offsetLeft,
-        imgUrl, 
+        imgRef,
         shrinkProportion,
         previewBoxSize,
         position,
@@ -60,7 +60,7 @@ const PreviewBox=React.forwardRef((props:IPreviewBoxProps,ref)=>{
                 ref={(ref as any)}
                 style={styles} 
             >
-                {imgUrl?<img src={imgUrl} style={imgStyles}/>:null}
+                {imgRef?<img src={imgRef.current?.src} style={imgStyles}/>:null}
             </div>
         </Popper>
     )

--- a/src/PreviewMagnifier.tsx
+++ b/src/PreviewMagnifier.tsx
@@ -26,8 +26,6 @@ const PreviewMagnifier = React.forwardRef((props: IPreviewMagnifierProps, ref) =
     const wrapperRef = useRef(null);
     //图片的size
     const [imgSize, setImgSize] = useState(0);
-    //图片的url
-    const [imgUrl,setImgUrl]=useState();
     //图片的节点
     const imgRef = useRef<any>(null);
     //预览图片的节点
@@ -43,7 +41,6 @@ const PreviewMagnifier = React.forwardRef((props: IPreviewMagnifierProps, ref) =
 
     useEffect(() => {
         const { width, height } = getBoundingClientRect(imgRef.current)
-        setImgUrl(imgRef?.current?.src); 
         setImgSize(Math.max(width, height))
     }, []);
 
@@ -103,7 +100,7 @@ const PreviewMagnifier = React.forwardRef((props: IPreviewMagnifierProps, ref) =
                 selectBoxSize={selectBoxSize}
                 previewBoxSize={previewBoxSize}
                 shrinkProportion={shrinkProportion}
-                imgUrl={imgUrl}
+                imgRef={imgRef}
                 position={position}
             />
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { MutableRefObject, ReactElement } from 'react';
 
 export { default } from './PreviewMagnifier';
 
@@ -41,7 +41,7 @@ export interface IPreviewBoxProps{
     visible:boolean;
     size:number;
     offsetLeft:number;//向左偏移量
-    imgUrl?:string;//图片的url
+    imgRef?:MutableRefObject<HTMLImageElement>;//Dom对象-img
     selectBoxSize?:number;//选择盒子的大小
     shrinkProportion?:number;////选择盒子占图片大小比例
     previewBoxSize:number;//预览盒子与原图大小比例


### PR DESCRIPTION
- 之前的
  
![前](https://user-images.githubusercontent.com/52687004/128596710-fea2d1b7-7c37-4853-81b6-845b35ac5933.gif)

---

- 之后的
 
![后](https://user-images.githubusercontent.com/52687004/128596716-62611fb5-dfd6-4f87-baed-24b34239c7b5.gif)
